### PR TITLE
feat(web): send draft to wechat without toUser

### DIFF
--- a/apps/web/src/config/wechat-credentials.ts
+++ b/apps/web/src/config/wechat-credentials.ts
@@ -1,0 +1,12 @@
+export interface WechatCredentials {
+  appId: string
+  appSecret: string
+}
+
+// Fill in your official account credentials here.
+export const wechatCredentials: WechatCredentials = {
+  appId: ``,
+  appSecret: ``,
+}
+
+export default wechatCredentials


### PR DESCRIPTION
## Summary
- remove `toUser` from wechat credential config
- post editor preview to WeChat draft API instead of custom message

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: vue-tsc: not found)*
- `pnpm --filter @md/web type-check`

------
https://chatgpt.com/codex/tasks/task_e_68aefa8e4c90832eab30e06985b151e2